### PR TITLE
Bug 26355: Make sure only Windows users on Windows7+ are trying to us…

### DIFF
--- a/torbrowser.nsi
+++ b/torbrowser.nsi
@@ -6,6 +6,7 @@
 ;Modern" UI
 
   !include "MUI2.nsh"
+  !include "WinVer.nsh"
 
 ;--------------------------------
 ;General
@@ -144,6 +145,12 @@ FunctionEnd
 ;Installer Functions
 
 Function .onInit
+
+  ${IfNot} ${AtLeastWin7}
+    MessageBox MB_USERICON|MB_OK "Tor Browser requires at least Windows 7"
+    SetErrorLevel 1
+    Quit
+  ${EndIf}
 
   !insertmacro MUI_LANGDLL_DISPLAY
 


### PR DESCRIPTION
…e Tor Browser based on ESR60 (tbb-windows-installer)

Added check to NSIS installer prior to language selection requiring
Windows 7 or later.  Aborts with user error popup if version is too
old.  Verified builds as expected with RBM and verified behaviour in a
Vista and Windows 7 VMs.

https://trac.torproject.org/projects/tor/ticket/26355